### PR TITLE
return 128 if default-directory does not exist

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -79,7 +79,9 @@ character for signs of changes"
 (make-variable-buffer-local 'git-gutter:overlays)
 
 (defun git-gutter:in-git-repository-p ()
-  (call-process-shell-command "git rev-parse --is-inside-work-tree"))
+  (if (and default-directory (file-directory-p default-directory))
+      (call-process-shell-command "git rev-parse --is-inside-work-tree")
+    128))
 
 (defun git-gutter:root-directory ()
   (with-temp-buffer

--- a/test-git-gutter.el
+++ b/test-git-gutter.el
@@ -80,4 +80,9 @@
           do
           (should (eql (plist-get diffinfo2 prop) expected)))))
 
+(ert-deftest git-gutter:in-git-repository-p ()
+  "Should return 128 if default-directory does not exist"
+  (let ((default-directory "/non/exist/directory"))
+    (should (eql 128 (git-gutter:in-git-repository-p)))))
+
 ;;; test-git-gutter.el end here


### PR DESCRIPTION
Invoking call-process-shell-command in a non-existing default-directory
will throw error.
