### PR TITLE
Update modeline when git-gutter:toggle is called in minor-mode

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -440,10 +440,14 @@ character for signs of changes"
   "toggle to show diff information"
   (interactive)
   (let ((git-gutter:force t))
-    (if git-gutter:enabled
-        (git-gutter:clear)
-      (git-gutter)))
-  (setq git-gutter:toggle-flag git-gutter:enabled))
+    (cond (git-gutter:enabled
+	   (git-gutter:clear)
+	   (setq git-gutter-mode nil))
+	  (t
+	   (git-gutter)
+	   (setq git-gutter-mode t)))
+  (setq git-gutter:toggle-flag git-gutter:enabled)
+  (force-mode-line-update)))
 
 (defun git-gutter:check-file-and-directory ()
   (and (buffer-file-name)


### PR DESCRIPTION
マイナーモードで git-gutter-mode を利用しています。
git-gutter:toggle を実行しても、モードラインに ”Git-Gutter” が表示されませんでした。

この変更により、
git-gutter:toggle 実行の度に、モードラインの表示がトグルします。
