### PR TITLE
Removed extra paren in define-minor-mode

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -450,7 +450,7 @@ character for signs of changes"
        default-directory (file-directory-p default-directory)))
 
 ;;;###autoload
-(define-minor-mode git-gutter-mode ()
+(define-minor-mode git-gutter-mode
   "Git-Gutter mode"
   :group      'git-gutter
   :init-value nil


### PR DESCRIPTION
It doesn't have an arguments list
