### PR TITLE
Improve updating after specified commands

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -673,7 +673,7 @@ character for signs of changes"
 
 (defadvice vc-revert (after git-gutter:vc-revert activate)
   (when git-gutter-mode
-    (git-gutter)))
+    (run-with-idle-timer 0.1 nil 'git-gutter)))
 
 ;;;###autoload
 (defun git-gutter:clear ()


### PR DESCRIPTION
- remove needless defadvice
- use defadvice for 'vc-revert' instead of git-gutter:update-commands
- add ignore command exit-minibuffer

Cc: @thierryvolpiatto #53 
