### PR TITLE
add Magit hook to git-gutter:update-hooks

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -67,7 +67,7 @@ gutter information of other windows."
 
 (defcustom git-gutter:update-hooks
   '(after-save-hook after-revert-hook find-file-hook after-change-major-mode-hook
-    text-scale-mode-hook)
+    text-scale-mode-hook magit-revert-buffer-hook)
   "hook points of updating gutter"
   :type '(list (hook :tag "HookPoint")
                (repeat :inline t (hook :tag "HookPoint")))


### PR DESCRIPTION
If the user has Magit, the buffer will update when a change is committed or staged.

If the user doesn't have Magit, then nothing changes.  Emacs will create a variable `magit-revert-buffer-hook` that is never run.  No error is produced.

The motivation for this fix is that the git-gutter indicator `[+-=]` would not update after committing a change in Magit.  I think this fixes a common pain point for many users.  

Here's a related stackoverflow question that prompted this tweak.
http://stackoverflow.com/questions/23344540
