### PR TITLE
Add bzr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Introduction
 `git-gutter.el` is port of [GitGutter](https://github.com/jisaacks/GitGutter)
-which is a plugin of Sublime Text. `git-gutter.el` supports `git` and `mercurial`.
+which is a plugin of Sublime Text. `git-gutter.el` supports `git`, `mercurial`
+and `bazaar`.
 
 
 `git-gutter.el` also supports TRAMP so you can use `git-gutter.el` for remote files.
@@ -18,6 +19,7 @@ which is a plugin of Sublime Text. `git-gutter.el` supports `git` and `mercurial
 * Emacs 24 or higher
 * [Git](http://git-scm.com/) 1.7.0 or higher
 * [Mercurial](http://mercurial.selenic.com/)
+* [Bazaar](http://bazaar.canonical.com/)
 
 
 ## git-gutter.el vs [git-gutter-fringe.el](https://github.com/syohex/emacs-git-gutter-fringe)
@@ -72,7 +74,7 @@ Jump to previous hunk(alias `git-gutter:previous-diff`)
 
 #### `git-gutter:set-start-revision`
 
-Set start revision where got diff(`git diff` or `hg diff`) from.
+Set start revision where got diff(`git diff`, `hg diff` or `bzr diff`) from.
 
 #### `git-gutter:popup-hunk`
 
@@ -190,7 +192,7 @@ character.
 
 ### Backends
 
-`git-gutter.el` supports `git` and `mercurial` backends.
+`git-gutter.el` supports `git`, `mercurial`, and `bazaar` backends.
 You can set backends which `git-gutter.el` will be used.
 Default value of `git-gutter:handled-backends` is `'(git hg)`
 

--- a/git-gutter.el
+++ b/git-gutter.el
@@ -50,6 +50,11 @@ character for signs of changes"
   :type 'string
   :group 'git-gutter)
 
+(defcustom git-gutter:bazaar-diff-option ""
+  "Option of 'bzr diff'"
+  :type 'string
+  :group 'git-gutter)
+
 (defcustom git-gutter:update-commands
   '(ido-switch-buffer helm-buffers-list)
   "Each command of this list is executed, gutter information is updated."
@@ -145,7 +150,7 @@ gutter information of other windows."
 
 (defcustom git-gutter:handled-backends '(git hg)
   "List of version control backends for which `git-gutter.el` will be used.
-`git' and `hg' are supported."
+`git', `hg', and `bzr' are supported."
   :type '(repeat symbol)
   :group 'git-gutter)
 
@@ -211,10 +216,17 @@ gutter information of other windows."
        (zerop (git-gutter:execute-command "hg" nil "root"))
        (not (string-match-p "/\.hg/" default-directory))))
 
+(defun git-gutter:in-bzr-repository-p ()
+  (and (executable-find "bzr")
+       (locate-dominating-file default-directory ".bzr")
+       (zerop (git-gutter:execute-command "bzr" nil "root"))
+       (not (string-match-p "/\.bzr/" default-directory))))
+
 (defsubst git-gutter:vcs-check-function (vcs)
   (cl-case vcs
     (git 'git-gutter:in-git-repository-p)
-    (hg 'git-gutter:in-hg-repository-p)))
+    (hg 'git-gutter:in-hg-repository-p)
+    (bzr 'git-gutter:in-bzr-repository-p)))
 
 (defsubst git-gutter:in-repository-p ()
   (cl-loop for vcs in git-gutter:handled-backends
@@ -302,10 +314,25 @@ gutter information of other windows."
   (let ((args (git-gutter:hg-diff-arguments file)))
     (apply 'start-file-process "git-gutter" proc-buf "hg" "diff" "-U0" args)))
 
+(defun git-gutter:bzr-diff-arguments (file)
+  (let (args)
+    (unless (string= git-gutter:bazaar-diff-option "")
+      (setq args (nreverse (split-string git-gutter:bazaar-diff-option))))
+    (when (git-gutter:revision-set-p)
+      (push "-r" args)
+      (push git-gutter:start-revision args))
+    (nreverse (cons file args))))
+
+(defsubst git-gutter:start-bzr-diff-process (file proc-buf)
+  (let ((args (git-gutter:bzr-diff-arguments file)))
+    (apply 'start-file-process "git-gutter" proc-buf
+           "bzr" "diff" "--context=0" args)))
+
 (defun git-gutter:start-diff-process1 (file proc-buf)
   (cl-case git-gutter:vcs-type
     (git (git-gutter:start-git-diff-process file proc-buf))
-    (hg (git-gutter:start-hg-diff-process file proc-buf))))
+    (hg (git-gutter:start-hg-diff-process file proc-buf))
+    (bzr (git-gutter:start-bzr-diff-process file proc-buf))))
 
 (defun git-gutter:start-diff-process (curfile proc-buf)
   (git-gutter:set-window-margin (git-gutter:window-margin))
@@ -841,7 +868,9 @@ gutter information of other windows."
            (git (git-gutter:execute-command "git" nil
                                             "rev-parse" "--quiet" "--verify"
                                             revision))
-           (hg (git-gutter:execute-command "hg" nil "id" "-r" revision)))))
+           (hg (git-gutter:execute-command "hg" nil "id" "-r" revision))
+           (bzr (git-gutter:execute-command "bzr" nil
+                                            "revno" "-r" revision)))))
 
 ;;;###autoload
 (defun git-gutter:set-start-revision (start-rev)

--- a/test/test-git-gutter.el
+++ b/test/test-git-gutter.el
@@ -203,11 +203,24 @@ bar
            (got (git-gutter:hg-diff-arguments file)))
       (should (equal got '("-a" "-b" "-c" "-r" "30000" "git-gutter.el"))))))
 
+(ert-deftest git-gutter-bzr-diff-arguments ()
+  "Command line options of `bzr diff'"
+
+  (let ((git-gutter:bazaar-diff-option "-a -b -c")
+        (file "git-gutter.el"))
+    (let ((got (git-gutter:bzr-diff-arguments file)))
+      (should (equal got '("-a" "-b" "-c" "git-gutter.el"))))
+
+    (let* ((git-gutter:start-revision "30000")
+           (got (git-gutter:bzr-diff-arguments file)))
+      (should (equal got '("-a" "-b" "-c" "-r" "30000" "git-gutter.el"))))))
+
 (ert-deftest git-gutter-vcs-check-functions ()
   "Check function of VCS"
 
   (should (eq (git-gutter:vcs-check-function 'git) 'git-gutter:in-git-repository-p))
-  (should (eq (git-gutter:vcs-check-function 'hg) 'git-gutter:in-hg-repository-p)))
+  (should (eq (git-gutter:vcs-check-function 'hg) 'git-gutter:in-hg-repository-p))
+  (should (eq (git-gutter:vcs-check-function 'bzr) 'git-gutter:in-bzr-repository-p)))
 
 (ert-deftest git-gutter-read-header ()
   "Read header of diff hunk"


### PR DESCRIPTION
Hey, this adds [bazaar](http://bazaar.canonical.com/en/) support to emacs-git-gutter. It's working as expected from the small amount of use I've done.
