### PR TITLE
Fix flickering gutter when in terminal

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -346,7 +346,6 @@ gutter information of other windows."
     (bzr (git-gutter:start-bzr-diff-process file proc-buf))))
 
 (defun git-gutter:start-diff-process (curfile proc-buf)
-  (git-gutter:set-window-margin (git-gutter:window-margin))
   (let ((file (git-gutter:base-file)) ;; for tramp
         (curbuf (current-buffer))
         (process (git-gutter:start-diff-process1 curfile proc-buf)))


### PR DESCRIPTION
When calling `git-gutter` with no diffs to show in the gutter, the gutter will quickly show and then disappear, this manifests as a horizontal flickering when using emacs in terminal mode. In doom-emacs, which I use, git-gutter is called when switching windows, so there is an annoying flicker anytime one switches windows. `git-gutter:view-diff-infos` calls `git-gutter:show-gutter` which appears to also execute the call to `git-gutter:set-window-margin` which is removed in this diff so the margin should still be shown when needed. I tested this a little and didn't see any problems.