### PR TITLE
Fixed issue with undo of first unsaved change not updating gutter

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -222,7 +222,7 @@ Can be a directory-local variable in your project.")
 (defvar git-gutter:vcs-type nil)
 (defvar git-gutter:revision-history nil)
 (defvar git-gutter:update-timer nil)
-(defvar git-gutter:last-sha1 nil)
+(defvar git-gutter:last-chars-modified-tick nil)
 
 (defvar git-gutter:popup-buffer "*git-gutter:diff*")
 (defvar git-gutter:ignore-commands
@@ -1059,9 +1059,9 @@ start revision."
              (delete-file now))))))))
 
 (defun git-gutter:should-update-p ()
-  (let ((sha1 (secure-hash 'sha1 (current-buffer))))
-    (unless (equal sha1 git-gutter:last-sha1)
-      (setq git-gutter:last-sha1 sha1))))
+  (let ((chars-modified-tick (buffer-chars-modified-tick)))
+    (unless (equal chars-modified-tick git-gutter:last-chars-modified-tick)
+      (setq-local git-gutter:last-chars-modified-tick chars-modified-tick))))
 
 (defun git-gutter:git-root ()
   (with-temp-buffer
@@ -1073,7 +1073,6 @@ start revision."
 (defun git-gutter:live-update ()
   (git-gutter:awhen (git-gutter:base-file)
     (when (and git-gutter:enabled
-               (buffer-modified-p)
                (git-gutter:should-update-p))
       (let ((file (file-name-nondirectory it))
             (root (file-truename (git-gutter:git-root)))


### PR DESCRIPTION
Fixes #172.

This change removes the condition that the buffer must be modified (from `git-gutter:live-update`) in order to perform an update to the gutter.  I assume this "modified" conditional was originally added to as an optimization to prevent recomputing the SHA1 each time the timer expires.  However, I don't believe computing the hash is even necessary and this change uses `buffer-chars-modified-tick` instead to look for changes to the buffer.  This allows the gutter to be refreshed even when an undo is performed which brings the buffer back to a unmodified state.

Additionally, it appears that the previous `git-gutter:last-sha1` variable was global when I believe it should have been local.  I made the replacement variable `git-gutter:last-chars-modified-tick` buffer local.  It seems having the `last-sha1` shared between multiple buffers may have created odd behavior or excessive re-computations unnecessarily.