### PR TITLE
Use `--` to separate paths from revisions

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -338,7 +338,7 @@ Argument TEST is the case before BODY execution."
   (let ((arg (git-gutter:git-diff-arguments file)))
     (apply #'start-file-process "git-gutter" proc-buf
            "git" "--no-pager" "-c" "diff.autorefreshindex=0"
-           "diff" "--no-color" "--no-ext-diff" "--relative" "-U0"
+           "diff" "--no-color" "--no-ext-diff" "--relative" "-U0" "--"
            arg)))
 
 (defun git-gutter:svn-diff-arguments (file)


### PR DESCRIPTION
This PR add `--` argument to separate paths from revisions explicitly.

`git diff` get confused when there is a branch with the same name as the file name.

```
$ echo '; blah' >> Cask

$ git --no-pager diff -U0 Cask
diff --git a/Cask b/Cask
index 5996224..341da34 100644
--- a/Cask
+++ b/Cask
@@ -8,0 +9 @@
+; blah

### create a branch named `Cask`
$ git checkout -b Cask
Switched to a new branch 'Cask'

$ git checkout  master
M       Cask
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

### git diff get confused
$ git --no-pager diff -U0 Cask
fatal: ambiguous argument 'Cask': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

### add `--` to separate path
$ git --no-pager diff -U0 -- Cask
diff --git a/Cask b/Cask
index 5996224..341da34 100644
--- a/Cask
+++ b/Cask
@@ -8,0 +9 @@
+; blah
```

