### PR TITLE
Modify update-all-windows to also apply to windows in other frames.

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -1012,8 +1012,8 @@ start revision."
 (defun git-gutter:update-all-windows ()
   "Update git-gutter information for all visible buffers."
   (interactive)
-  (dolist (win (window-list))
-    (let ((buf (window-buffer win)))
+  (dolist (buf (buffer-list))
+    (when (get-buffer-window buf 'visible)
       (with-current-buffer buf
         (when git-gutter-mode
           (git-gutter))))))


### PR DESCRIPTION
Fixes #196.

Instead of starting with the result of calling `window-list`, which is only applicable to the current frame, we instead start with `buffer-list` and then filter that based on whether it's associated with a visible window, regardless of which frame it happens to reside in.  Once we have that list, we can apply the same check for `git-gutter-mode` before invoking `git-gutter` on the buffer.
