### PR TITLE
Use display-buffer instead of pop-to-buffer for popup-hunk

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -881,7 +881,7 @@ Argument TEST is the case before BODY execution."
   (git-gutter:awhen (or diffinfo
                         (git-gutter:search-here-diffinfo git-gutter:diffinfos))
     (save-selected-window
-      (pop-to-buffer (git-gutter:update-popuped-buffer it)))))
+      (display-buffer (git-gutter:update-popuped-buffer it)))))
 
 (defun git-gutter:next-hunk (arg)
   "Move to next diff hunk"


### PR DESCRIPTION
It makes git-gutter:popup-hunk less agressive and commands like magit,
list-buffers, which open buffer in other-window will work as usual.