### PR TITLE
Fix indirect buffer

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -220,7 +220,7 @@ Can be a directory-local variable in your project.")
 
 (defvar git-gutter:enabled nil)
 (defvar git-gutter:diffinfos nil)
-(defvar git-gutter:has-indirect-buffers nil)
+(defvar-local git-gutter:has-indirect-buffers nil)
 (defvar git-gutter:real-this-command nil)
 (defvar git-gutter:linum-enabled nil)
 (defvar git-gutter:linum-prev-window-margin nil)
@@ -604,7 +604,6 @@ Argument TEST is the case before BODY execution."
             (when git-gutter:init-function
               (funcall git-gutter:init-function))
             (make-local-variable 'git-gutter:enabled)
-            (setq-local git-gutter:has-indirect-buffers nil)
             (make-local-variable 'git-gutter:diffinfos)
             ;;(setq-local git-gutter:start-revision nil)
             (add-hook 'kill-buffer-hook 'git-gutter:kill-buffer-hook nil t)

--- a/git-gutter.el
+++ b/git-gutter.el
@@ -953,10 +953,23 @@ Argument TEST is the case before BODY execution."
         (git-gutter:start-diff-process (file-name-nondirectory file)
                                        (get-buffer-create proc-buf))))))
 
-(defun git-gutter:make-indirect-buffer (&rest _args)
-  (when (and git-gutter-mode (not (buffer-base-buffer)))
-    (setq git-gutter:has-indirect-buffers t)))
-(advice-add 'make-indirect-buffer :before #'git-gutter:make-indirect-buffer)
+(defun git-gutter:kill-indirect-buffer ()
+  (with-current-buffer (buffer-base-buffer)
+    (when git-gutter:has-indirect-buffers
+      (if (< 1 git-gutter:has-indirect-buffers)
+          (setq git-gutter:has-indirect-buffers (1- git-gutter:has-indirect-buffers))
+        (setq git-gutter:has-indirect-buffers nil)))))
+
+(defun git-gutter:make-indirect-buffer (oldfun base-buffer &rest args)
+  (with-current-buffer (or (buffer-base-buffer (window-normalize-buffer base-buffer))
+                           base-buffer)
+    (if git-gutter:has-indirect-buffers
+        (setq git-gutter:has-indirect-buffers (1+ git-gutter:has-indirect-buffers))
+      (setq git-gutter:has-indirect-buffers 1))
+    (with-current-buffer (apply oldfun base-buffer args)
+      (add-hook 'kill-buffer-hook #'git-gutter:kill-indirect-buffer nil t)
+      (current-buffer))))
+(advice-add 'make-indirect-buffer :around #'git-gutter:make-indirect-buffer)
 
 (defun git-gutter:vc-revert (&rest _args)
   (when git-gutter-mode

--- a/git-gutter.el
+++ b/git-gutter.el
@@ -220,7 +220,7 @@ Can be a directory-local variable in your project.")
 
 (defvar git-gutter:enabled nil)
 (defvar git-gutter:diffinfos nil)
-(defvar-local git-gutter:has-indirect-buffers nil)
+(defvar git-gutter:has-indirect-buffers nil)
 (defvar git-gutter:real-this-command nil)
 (defvar git-gutter:linum-enabled nil)
 (defvar git-gutter:linum-prev-window-margin nil)
@@ -957,14 +957,14 @@ Argument TEST is the case before BODY execution."
     (when git-gutter:has-indirect-buffers
       (if (< 1 git-gutter:has-indirect-buffers)
           (setq git-gutter:has-indirect-buffers (1- git-gutter:has-indirect-buffers))
-        (setq git-gutter:has-indirect-buffers nil)))))
+        (kill-local-variable 'git-gutter:has-indirect-buffers)))))
 
 (defun git-gutter:make-indirect-buffer (oldfun base-buffer &rest args)
   (with-current-buffer (or (buffer-base-buffer (window-normalize-buffer base-buffer))
                            base-buffer)
     (if git-gutter:has-indirect-buffers
         (setq git-gutter:has-indirect-buffers (1+ git-gutter:has-indirect-buffers))
-      (setq git-gutter:has-indirect-buffers 1))
+      (setq-local git-gutter:has-indirect-buffers 1))
     (with-current-buffer (apply oldfun base-buffer args)
       (add-hook 'kill-buffer-hook #'git-gutter:kill-indirect-buffer nil t)
       (current-buffer))))


### PR DESCRIPTION
I had a few problems with showing git-gutter in indirect buffers. I was able to fix most of them, I posted an issue for the one I couldn't figure out.

`git-gutter:make-indirect-buffer` assumed that the base buffer was the active buffer, this would sometimes cause it to set `git-gutter:has-indirect-buffer` to true in the wrong buffer. I fixed this.

I also changed `git-gutter:has-indirect-buffer` to the count of indirect buffers when it is not nil, so that it can be set back to nil when the count reaches 0. I did this to help with some packages that make and remove a bunch of indirect buffer like minimaps.

lastly git-gutter would only track new indirect buffers when it was active and would forget if it had any when turned off and on again. the way I fixed this was to track the number of indirect buffers for each buffer, this feels reasonable has indirect buffers aren't made that often.