### PR TITLE
Fix git-gutter:start-live-update, git-gutter:enabled in every buffer

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -218,7 +218,7 @@ Can be a directory-local variable in your project.")
 (cl-defstruct git-gutter-hunk
   type content start-line end-line)
 
-(defvar git-gutter:enabled nil)
+(defvar-local git-gutter:enabled nil)
 (defvar git-gutter:diffinfos nil)
 (defvar git-gutter:has-indirect-buffers nil)
 (defvar git-gutter:real-this-command nil)
@@ -603,7 +603,6 @@ Argument TEST is the case before BODY execution."
           (progn
             (when git-gutter:init-function
               (funcall git-gutter:init-function))
-            (make-local-variable 'git-gutter:enabled)
             (setq-local git-gutter:has-indirect-buffers nil)
             (make-local-variable 'git-gutter:diffinfos)
             ;;(setq-local git-gutter:start-revision nil)


### PR DESCRIPTION
Although I can not find immediately why (from investigating the source code),
when using `global-git-gutter-mode`, git-gutter:enabled is t in every buffer,
even in buffers where `git-gutter-mode` is disabled (see latest comments in
Spacemacs issue https://github.com/syl20bnr/spacemacs/issues/15106), causing the
body of `git-gutter:live-update` to run in buffers where it should
not (messaging errors).

Making the variable `git-gutter:enabled` buffer local immediately on creation
solves the issue (while `git-gutter:enabled` is still t in buffers where it
should).

=================================================================
Use a dedicated feature branch
=================================================================

Please use a dedicated feature branch for your feature request, instead of asking us to merge "your-fork/master" into the "origin/master".  The use of dedicated branches makes it much more convenient to deal with pull-requests, especially when using Magit to do so.

If you were about to open a pull-request asking us to merge your version of "master", then see [1] for instructions on how to quickly fix that and some information on why we ask you to do so.

Additionally we ask you to allow us to push to the branch you want us to merge.  We might want to push additional commits and/or make minor changes.  Please make sure the box next to "Allow edits from maintainers" is checked before creating the pull-request.

  [1]: https://github.com/magit/magit/wiki/Dedicated-pull-request-branches

=================================================================
Do NOT use Github to edit files and create commit messages
=================================================================

Unless you are aware of all the pitfalls and take great care to avoid them, the use of Github results in many small defects, including but not limited to trailing whitespace, commit messages containing overlong lines and no newline at the very end, and "GitHub <noreply@github.com>" being used as the committer.  The last one cannot even be avoided, which I consider as an affront.

Github is an insufficient interface for editing files and creating commits.  Please don't do it when contributing to this project.

=================================================================
What you should write here
=================================================================

Please summarize the changes made in the commits.  Explain why you are making these changes, not just what changes you are making.  This also applies to the commit messages.

=================================================================
How to update the manual
=================================================================

If this project has a manual and you make changes to that, then edit only "PROJECT.org".  Do not manually edit "PROJECT.texi".  The latter has to be generated from the former.  If you want to do that yourself, then follow the instructions at [2].  Otherwise a maintainer will do it and amend that to your commit.

  [2]: https://github.com/magit/magit/wiki/Documentation-tools-and-conventions
