### PR TITLE
Fix Emacs 29 startup bug

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -530,7 +530,7 @@ Argument TEST is the case before BODY execution."
          (git-gutter))
         ((memq git-gutter:real-this-command git-gutter:update-windows-commands)
          (git-gutter)
-         (unless global-linum-mode
+         (unless (bound-and-true-p global-linum-mode)
            (git-gutter:update-other-window-buffers (selected-window)
                                                    (current-buffer))))))
 
@@ -1143,7 +1143,7 @@ start revision."
           (delete-file original))))))
 
 ;; for linum-user
-(when (and global-linum-mode (not (boundp 'git-gutter-fringe)))
+(when (and (bound-and-true-p global-linum-mode) (not (boundp 'git-gutter-fringe)))
   (git-gutter:linum-setup))
 
 (defun git-gutter:all-hunks ()


### PR DESCRIPTION
Emacs 29 has now marked global-linum-mode as obsolete and does not
autoload the variable, so without this patch, Emacs 29 users will
encounter an error upon startup.