### PR TITLE
Emacs 29 build fix

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -1143,7 +1143,7 @@ start revision."
           (delete-file original))))))
 
 ;; for linum-user
-(when (and (bound-and-true-p global-linum-mode) (not (boundp 'git-gutter-fringe)))
+(when (and (and (boundp 'global-linum-mode) global-linum-mode) (not (boundp 'git-gutter-fringe)))
   (git-gutter:linum-setup))
 
 (defun git-gutter:all-hunks ()


### PR DESCRIPTION
Fixes build issues on Emacs 29+, due to the use of a undefined var global-linum-mode
Resolves #226, resolves #229