### PR TITLE
Change `when-let` to `when-let*` since it will be obsolete by emacs31

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -250,8 +250,8 @@ Argument TEST is the case before BODY execution."
 (defun git-gutter:in-git-repository-p ()
   (when (executable-find "git" t)
     (with-temp-buffer
-      (when-let ((exec-result (git-gutter:execute-command
-                               "git" t "rev-parse" "--is-inside-work-tree")))
+      (when-let* ((exec-result (git-gutter:execute-command
+                                "git" t "rev-parse" "--is-inside-work-tree")))
         (when (zerop exec-result)
           (goto-char (point-min))
           (looking-at-p "true"))))))


### PR DESCRIPTION
The `when-let` macro will be obsolete by Emacs-31.1; the next stable version of 30.0 will make warnings on it. So we have to change it to `when-let*`.
Just a small patch, but thank you in advance.