### PR TITLE
Allow killing indirect when base buffer has already been killed.

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -953,11 +953,12 @@ Argument TEST is the case before BODY execution."
                                        (get-buffer-create proc-buf))))))
 
 (defun git-gutter:kill-indirect-buffer ()
-  (with-current-buffer (buffer-base-buffer)
-    (when git-gutter:has-indirect-buffers
-      (if (< 1 git-gutter:has-indirect-buffers)
-          (setq git-gutter:has-indirect-buffers (1- git-gutter:has-indirect-buffers))
-        (kill-local-variable 'git-gutter:has-indirect-buffers)))))
+  (when (buffer-live-p (buffer-base-buffer))
+    (with-current-buffer (buffer-base-buffer)
+      (when git-gutter:has-indirect-buffers
+        (if (< 1 git-gutter:has-indirect-buffers)
+            (setq git-gutter:has-indirect-buffers (1- git-gutter:has-indirect-buffers))
+          (kill-local-variable 'git-gutter:has-indirect-buffers))))))
 
 (defun git-gutter:make-indirect-buffer (oldfun base-buffer &rest args)
   (with-current-buffer (or (buffer-base-buffer (window-normalize-buffer base-buffer))


### PR DESCRIPTION
An unrelated activity killed a base buffer in a way that left its indirect buffer hanging around, and when I tried to kill off the indirect buffer manually I was blocked by an error in this hook function.  (`with-current-buffer` complains when trying to activate a killed buffer)  

So here's a quick patch to guard against that issue.